### PR TITLE
prevent tar warning on paths of more than 100 bytes

### DIFF
--- a/R/run_metadata.R
+++ b/R/run_metadata.R
@@ -156,10 +156,16 @@ write_source_archive <- function(sources_dir, data_dir, archive) {
   wd <- getwd()
   on.exit(setwd(wd), add = TRUE)
   setwd(file.path(sources_dir, ".."))
-  utils::tar(file.path(data_dir, archive),
-             files = "source",
-             compression = "gzip",
-             tar = "internal")
+  # tar and prevent "storing paths of more than 100 bytes is not
+  # portable" warning issued by R
+  suppressWarnings(
+    utils::tar(
+      file.path(data_dir, archive),
+      files = "source",
+      compression = "gzip",
+      tar = "internal"
+    )
+  )
 }
 
 


### PR DESCRIPTION
addresses https://github.com/rstudio/tfruns/issues/2

@kevinushey Could you review just to make sure this is what you had in mind?