### PR TITLE
Fix hard-coded steps_completed_unit in ls_runs()

### DIFF
--- a/R/ls_runs.R
+++ b/R/ls_runs.R
@@ -287,8 +287,9 @@ run_record <- function(run_dir) {
     }
   }
 
+  steps_completed_unit <- get_steps_completed_unit(get_steps_unit(columns))
   # epochs completed
-  columns$epochs_completed <- epochs_completed
+  columns[[steps_completed_unit]] <- epochs_completed
 
   # flags
   columns <- append(columns, read_json_columns("flags.json", "flag"))
@@ -408,4 +409,19 @@ run_source_code <- function(script, run_dir) {
 }
 
 valid_steps_units <- c("steps", "epochs")
+
+get_steps_unit <- function(run) {
+  steps_unit <- "steps"
+  for (unit in valid_steps_units) {
+    if (!is.null(run[[unit]])) {
+      steps_unit <- unit
+      break
+    }
+  }
+  steps_unit
+}
+
+get_steps_completed_unit <- function(steps_unit) {
+  paste0(steps_unit, "_completed")
+}
 

--- a/R/training_run.R
+++ b/R/training_run.R
@@ -360,14 +360,8 @@ save_run_report <- function(run_dir = latest_run(), filename = "auto") {
   # training
 
   # determine the step units
-  steps_unit <- "steps"
-  for (unit in valid_steps_units) {
-    if (!is.null(run[[unit]])) {
-      steps_unit <- unit
-      break
-    }
-  }
-  steps_completed_unit <- paste0(steps_unit, "_completed")
+  steps_unit <- get_steps_unit(run)
+  steps_completed_unit <- get_steps_completed_unit(steps_unit)
 
   # format the steps
   if (!is.null(run[[steps_unit]]) && !is.null(run[[steps_completed_unit]])) {


### PR DESCRIPTION
This fixed the following issue for `tfruns::latest_run()`:

Before the fix:
```
$ steps              : int 10
$ epochs_completed    : int 10
```

After the fix:

```
$ steps              : int 10
$ steps_completed    : int 10
```