### PR TITLE
Skip --args from command line args

### DIFF
--- a/R/flags.R
+++ b/R/flags.R
@@ -305,7 +305,7 @@ parse_command_line <- function(arguments) {
     argument <- arguments[[i]]
 
     # skip any command line arguments without a '--' prefix
-    if (!grepl("^--", argument))
+    if (!grepl("^--", argument) || grepl("^--args$", argument))
       next
 
     # check to see if an '=' was specified for this argument

--- a/tests/testthat/test-flags.R
+++ b/tests/testthat/test-flags.R
@@ -38,4 +38,17 @@ test_that("flags_parse overrides based on config file values", {
   expect_equal(FLAGS$learning_rate, 0.03)
 })
 
+test_that("flags_parse skips --args for passthrough args", {
+  FLAGS <- flags(
+    flag_string("job_dir", ""),
+    flag_numeric("gradient_descent_optimizer", 0.5),
+    arguments = list(
+      "--args",
+      "--gradient-descent-optimizer",
+      "0.47",
+      "--job-dir",
+      "gs://rstudio-cloudml/mnist/staging/2")
+  )
 
+  expect_equal(FLAGS$gradient_descent_optimizer, 0.47)
+})


### PR DESCRIPTION
Hit a case in `cloudml` where I had to make python pass additional command line arguments to R using `--args`, in which case, we would want to skip this one from the command line.