### PR TITLE
Low-level grid specification

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,5 +55,5 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.0.9000
+RoxygenNote: 6.1.1
 VignetteBuilder: knitr

--- a/R/training_run.R
+++ b/R/training_run.R
@@ -128,7 +128,8 @@ training_run <- function(file = "train.R",
 #'   provided for each flag).
 #' @param flag_grid A data frame that contains pre-generated
 #'   combinations of flags (e.g. via [base::expand.grid()]). This can
-#'   be useful for batch processing of large grids. See 'Examples'.
+#'   be useful for batch processing of large grids as well as
+#'   for subsetting combinations. See 'Examples'.
 #' @param sample Sampling rate for flag combinations (defaults to
 #'   running all combinations).
 #' @param confirm Confirm before executing tuning run.
@@ -148,13 +149,16 @@ training_run <- function(file = "train.R",
 #' ))
 #' runs[order(runs$eval_acc, decreasing = TRUE), ]
 #'
-#' # using the flag_grid argument
-#' grid <- grid.expand(
+#' # using the flag_grid argument, but remove combinations
+#' # where the combined dropout rate exceeds 1
+#' grid <- expand.grid(
 #'   batch_size = 2^c(1:5),
 #'   dropout1 = seq(0.2, 0.8, by = 0.1),
 #'   dropout2 = seq(0.2, 0.8, by = 0.1)
 #' )
+#' grid$combined_droput <- grid$dropout1 + grid$dropout2
 #' grid$id <- 1:nrow(grid)
+#' grid <- grid[grid$combined_droput <= 1,]
 #' runs <- tuning_run("mnist_mlp.R", flag_grid = grid, sample = 0.01)
 #' # check if an arbitrary run has been completed
 #' completed_runs <- runs[runs$completed]$id

--- a/R/training_run.R
+++ b/R/training_run.R
@@ -178,7 +178,6 @@ tuning_run <- function(file = "train.R",
                        confirm = interactive(),
                        envir = parent.frame(),
                        encoding = getOption("encoding")) {
-  #' TODO must be data frame, must not have facor levels!
   if ((is.null(flags) && is.null(flag_grid)) || (!is.null(flags) && !is.null(flag_grid)))
     stop("Flags must be specified either via the argument 'flags' or 'flag_grid'")
 

--- a/R/training_run.R
+++ b/R/training_run.R
@@ -126,9 +126,8 @@ training_run <- function(file = "train.R",
 #'
 #' @param flags Either a named list with flag values (multiple values can be
 #'   provided for each flag) or a data frame that contains pre-generated
-#'   combinations of flags (e.g. via [base::expand.grid()]). This second can
-#'   be useful for batch processing of large grids as well as
-#'   for subsetting combinations. See 'Examples'.
+#'   combinations of flags (e.g. via [base::expand.grid()]). The latter can
+#'   be useful for subsetting combinations. See 'Examples'.
 #' @param sample Sampling rate for flag combinations (defaults to
 #'   running all combinations).
 #' @param confirm Confirm before executing tuning run.
@@ -154,27 +153,16 @@ training_run <- function(file = "train.R",
 #' # resulting in the same combinations above, but remove those
 #' # where the combined dropout rate exceeds 1
 #' grid <- expand.grid(
-#'   dropout1 = seq(0.2, 0.8, by = 0.1),
-#'   dropout2 = seq(0.2, 0.8, by = 0.1)
+#'   dropout1 = c(0.2, 0.3, 0.4),
+#'   dropout2 = c(0.2, 0.3, 0.4)
 #' )
 #' grid$combined_droput <- grid$dropout1 + grid$dropout2
-#' grid$id <- 1:nrow(grid)
 #' grid <- grid[grid$combined_droput <= 1, ]
 #' runs <- tuning_run(
 #'   system.file("examples/mnist_mlp/mnist_mlp.R", package = "tfruns"),
-#'   flags = grid[, c("dropout1", "dropout2")], sample = 0.1
-#' )
-#' # check if an arbitrary run has been completed
-#' completed_runs <- runs[runs$completed]$id
-#' 2 %in% completed_runs
-#' # continue evaluating the grid if the process was paused / interrupted etc.
-#' grid <- grid[!(grid$id %in% completed_runs), ]
-#' runs <- tuning_run(
-#'   system.file("examples/mnist_mlp/mnist_mlp.R", package = "tfruns"),
-#'   flags = grid[, c("dropout1", "dropout2")], sample = 0.1
+#'   flags = grid[, c("dropout1", "dropout2")]
 #' )
 #' }
-#'
 #' @export
 tuning_run <- function(file = "train.R",
                        context = "local",

--- a/R/training_run.R
+++ b/R/training_run.R
@@ -141,31 +141,38 @@ training_run <- function(file = "train.R",
 #' library(tfruns)
 #'
 #' # using a list as input to the flags argument
-#' runs <- tuning_run("mnist_mlp.R", flags = list(
-#'   batch_size = c(64, 128),
-#'   dropout1 = c(0.2, 0.3, 0.4),
-#'   dropout2 = c(0.2, 0.3, 0.4)
-#' ))
+#' runs <- tuning_run(
+#'   system.file("examples/mnist_mlp/mnist_mlp.R", package = "tfruns"),
+#'   flags = list(
+#'     dropout1 = c(0.2, 0.3, 0.4),
+#'     dropout2 = c(0.2, 0.3, 0.4)
+#'   )
+#' )
 #' runs[order(runs$eval_acc, decreasing = TRUE), ]
 #'
 #' # using a data frame as input to the flags argument
 #' # resulting in the same combinations above, but remove those
 #' # where the combined dropout rate exceeds 1
 #' grid <- expand.grid(
-#'   batch_size = 2^c(1:5),
 #'   dropout1 = seq(0.2, 0.8, by = 0.1),
 #'   dropout2 = seq(0.2, 0.8, by = 0.1)
 #' )
 #' grid$combined_droput <- grid$dropout1 + grid$dropout2
 #' grid$id <- 1:nrow(grid)
-#' grid <- grid[grid$combined_droput <= 1,]
-#' runs <- tuning_run("mnist_mlp.R", flags = grid, sample = 0.01)
+#' grid <- grid[grid$combined_droput <= 1, ]
+#' runs <- tuning_run(
+#'   system.file("examples/mnist_mlp/mnist_mlp.R", package = "tfruns"),
+#'   flags = grid[, c("dropout1", "dropout2")], sample = 0.1
+#' )
 #' # check if an arbitrary run has been completed
 #' completed_runs <- runs[runs$completed]$id
 #' 2 %in% completed_runs
 #' # continue evaluating the grid if the process was paused / interrupted etc.
 #' grid <- grid[!(grid$id %in% completed_runs), ]
-#' runs <- tuning_run("mnist_mlp.R", flag_grid = grid, sample = 0.01)
+#' runs <- tuning_run(
+#'   system.file("examples/mnist_mlp/mnist_mlp.R", package = "tfruns"),
+#'   flags = grid[, c("dropout1", "dropout2")], sample = 0.1
+#' )
 #' }
 #'
 #' @export

--- a/man/tuning_run.Rd
+++ b/man/tuning_run.Rd
@@ -25,7 +25,8 @@ provided for each flag).}
 
 \item{flag_grid}{A data frame that contains pre-generated
 combinations of flags (e.g. via \code{\link[base:expand.grid]{base::expand.grid()}}). This can
-be useful for batch processing of large grids. See 'Examples'.}
+be useful for batch processing of large grids as well as
+for subsetting combinations. See 'Examples'.}
 
 \item{sample}{Sampling rate for flag combinations (defaults to
 running all combinations).}
@@ -70,13 +71,16 @@ runs <- tuning_run("mnist_mlp.R", flags = list(
 ))
 runs[order(runs$eval_acc, decreasing = TRUE), ]
 
-# using the flag_grid argument
-grid <- grid.expand(
+# using the flag_grid argument, but remove combinations
+# where the combined dropout rate exceeds 1
+grid <- expand.grid(
   batch_size = 2^c(1:5),
   dropout1 = seq(0.2, 0.8, by = 0.1),
   dropout2 = seq(0.2, 0.8, by = 0.1)
 )
+grid$combined_droput <- grid$dropout1 + grid$dropout2
 grid$id <- 1:nrow(grid)
+grid <- grid[grid$combined_droput <= 1,]
 runs <- tuning_run("mnist_mlp.R", flag_grid = grid, sample = 0.01)
 # check if an arbitrary run has been completed
 completed_runs <- runs[runs$completed]$id

--- a/man/tuning_run.Rd
+++ b/man/tuning_run.Rd
@@ -6,7 +6,7 @@
 \usage{
 tuning_run(file = "train.R", context = "local",
   config = Sys.getenv("R_CONFIG_ACTIVE", unset = "default"),
-  flags = NULL, sample = NULL, properties = NULL,
+  flags = NULL, flag_grid = NULL, sample = NULL, properties = NULL,
   runs_dir = getOption("tfruns.runs_dir", "runs"),
   artifacts_dir = getwd(), echo = TRUE, confirm = interactive(),
   envir = parent.frame(), encoding = getOption("encoding"))
@@ -21,7 +21,11 @@ for the current environment (as specified by the \code{R_CONFIG_ACTIVE}
 environment variable), or \code{default} when unset.}
 
 \item{flags}{Named list with flag values (multiple values can be
-provided for each flag)}
+provided for each flag).}
+
+\item{flag_grid}{A data frame that contains pre-generated
+combinations of flags (e.g. via \code{\link[base:expand.grid]{base::expand.grid()}}). This can
+be useful for batch processing of large grids. See 'Examples'.}
 
 \item{sample}{Sampling rate for flag combinations (defaults to
 running all combinations).}
@@ -58,14 +62,28 @@ will result in a random sample of the flag combinations being run.
 \dontrun{
 library(tfruns)
 
+# using the flags argument
 runs <- tuning_run("mnist_mlp.R", flags = list(
   batch_size = c(64, 128),
   dropout1 = c(0.2, 0.3, 0.4),
   dropout2 = c(0.2, 0.3, 0.4)
 ))
-
 runs[order(runs$eval_acc, decreasing = TRUE), ]
 
+# using the flag_grid argument
+grid <- grid.expand(
+  batch_size = 2^c(1:5),
+  dropout1 = seq(0.2, 0.8, by = 0.1),
+  dropout2 = seq(0.2, 0.8, by = 0.1)
+)
+grid$id <- 1:nrow(grid)
+runs <- tuning_run("mnist_mlp.R", flag_grid = grid, sample = 0.01)
+# check if an arbitrary run has been completed
+completed_runs <- runs[runs$completed]$id
+2 \%in\% completed_runs
+# continue evaluating the grid if the process was paused / interrupted etc.
+grid <- grid[!(grid$id \%in\% completed_runs), ]
+runs <- tuning_run("mnist_mlp.R", flag_grid = grid, sample = 0.01)
 }
 
 }

--- a/man/tuning_run.Rd
+++ b/man/tuning_run.Rd
@@ -6,7 +6,7 @@
 \usage{
 tuning_run(file = "train.R", context = "local",
   config = Sys.getenv("R_CONFIG_ACTIVE", unset = "default"),
-  flags = NULL, flag_grid = NULL, sample = NULL, properties = NULL,
+  flags = NULL, sample = NULL, properties = NULL,
   runs_dir = getOption("tfruns.runs_dir", "runs"),
   artifacts_dir = getwd(), echo = TRUE, confirm = interactive(),
   envir = parent.frame(), encoding = getOption("encoding"))
@@ -20,11 +20,9 @@ tuning_run(file = "train.R", context = "local",
 for the current environment (as specified by the \code{R_CONFIG_ACTIVE}
 environment variable), or \code{default} when unset.}
 
-\item{flags}{Named list with flag values (multiple values can be
-provided for each flag).}
-
-\item{flag_grid}{A data frame that contains pre-generated
-combinations of flags (e.g. via \code{\link[base:expand.grid]{base::expand.grid()}}). This can
+\item{flags}{Either a named list with flag values (multiple values can be
+provided for each flag) or a data frame that contains pre-generated
+combinations of flags (e.g. via \code{\link[base:expand.grid]{base::expand.grid()}}). This second can
 be useful for batch processing of large grids as well as
 for subsetting combinations. See 'Examples'.}
 
@@ -63,7 +61,7 @@ will result in a random sample of the flag combinations being run.
 \dontrun{
 library(tfruns)
 
-# using the flags argument
+# using a list as input to the flags argument
 runs <- tuning_run("mnist_mlp.R", flags = list(
   batch_size = c(64, 128),
   dropout1 = c(0.2, 0.3, 0.4),
@@ -71,7 +69,8 @@ runs <- tuning_run("mnist_mlp.R", flags = list(
 ))
 runs[order(runs$eval_acc, decreasing = TRUE), ]
 
-# using the flag_grid argument, but remove combinations
+# using a data frame as input to the flags argument
+# resulting in the same combinations above, but remove those
 # where the combined dropout rate exceeds 1
 grid <- expand.grid(
   batch_size = 2^c(1:5),
@@ -81,7 +80,7 @@ grid <- expand.grid(
 grid$combined_droput <- grid$dropout1 + grid$dropout2
 grid$id <- 1:nrow(grid)
 grid <- grid[grid$combined_droput <= 1,]
-runs <- tuning_run("mnist_mlp.R", flag_grid = grid, sample = 0.01)
+runs <- tuning_run("mnist_mlp.R", flags = grid, sample = 0.01)
 # check if an arbitrary run has been completed
 completed_runs <- runs[runs$completed]$id
 2 \%in\% completed_runs

--- a/man/tuning_run.Rd
+++ b/man/tuning_run.Rd
@@ -62,31 +62,38 @@ will result in a random sample of the flag combinations being run.
 library(tfruns)
 
 # using a list as input to the flags argument
-runs <- tuning_run("mnist_mlp.R", flags = list(
-  batch_size = c(64, 128),
-  dropout1 = c(0.2, 0.3, 0.4),
-  dropout2 = c(0.2, 0.3, 0.4)
-))
+runs <- tuning_run(
+  system.file("examples/mnist_mlp/mnist_mlp.R", package = "tfruns"),
+  flags = list(
+    dropout1 = c(0.2, 0.3, 0.4),
+    dropout2 = c(0.2, 0.3, 0.4)
+  )
+)
 runs[order(runs$eval_acc, decreasing = TRUE), ]
 
 # using a data frame as input to the flags argument
 # resulting in the same combinations above, but remove those
 # where the combined dropout rate exceeds 1
 grid <- expand.grid(
-  batch_size = 2^c(1:5),
   dropout1 = seq(0.2, 0.8, by = 0.1),
   dropout2 = seq(0.2, 0.8, by = 0.1)
 )
 grid$combined_droput <- grid$dropout1 + grid$dropout2
 grid$id <- 1:nrow(grid)
-grid <- grid[grid$combined_droput <= 1,]
-runs <- tuning_run("mnist_mlp.R", flags = grid, sample = 0.01)
+grid <- grid[grid$combined_droput <= 1, ]
+runs <- tuning_run(
+  system.file("examples/mnist_mlp/mnist_mlp.R", package = "tfruns"),
+  flags = grid[, c("dropout1", "dropout2")], sample = 0.1
+)
 # check if an arbitrary run has been completed
 completed_runs <- runs[runs$completed]$id
 2 \%in\% completed_runs
 # continue evaluating the grid if the process was paused / interrupted etc.
 grid <- grid[!(grid$id \%in\% completed_runs), ]
-runs <- tuning_run("mnist_mlp.R", flag_grid = grid, sample = 0.01)
+runs <- tuning_run(
+  system.file("examples/mnist_mlp/mnist_mlp.R", package = "tfruns"),
+  flags = grid[, c("dropout1", "dropout2")], sample = 0.1
+)
 }
 
 }

--- a/man/tuning_run.Rd
+++ b/man/tuning_run.Rd
@@ -22,9 +22,8 @@ environment variable), or \code{default} when unset.}
 
 \item{flags}{Either a named list with flag values (multiple values can be
 provided for each flag) or a data frame that contains pre-generated
-combinations of flags (e.g. via \code{\link[base:expand.grid]{base::expand.grid()}}). This second can
-be useful for batch processing of large grids as well as
-for subsetting combinations. See 'Examples'.}
+combinations of flags (e.g. via \code{\link[base:expand.grid]{base::expand.grid()}}). The latter can
+be useful for subsetting combinations. See 'Examples'.}
 
 \item{sample}{Sampling rate for flag combinations (defaults to
 running all combinations).}
@@ -75,25 +74,14 @@ runs[order(runs$eval_acc, decreasing = TRUE), ]
 # resulting in the same combinations above, but remove those
 # where the combined dropout rate exceeds 1
 grid <- expand.grid(
-  dropout1 = seq(0.2, 0.8, by = 0.1),
-  dropout2 = seq(0.2, 0.8, by = 0.1)
+  dropout1 = c(0.2, 0.3, 0.4),
+  dropout2 = c(0.2, 0.3, 0.4)
 )
 grid$combined_droput <- grid$dropout1 + grid$dropout2
-grid$id <- 1:nrow(grid)
 grid <- grid[grid$combined_droput <= 1, ]
 runs <- tuning_run(
   system.file("examples/mnist_mlp/mnist_mlp.R", package = "tfruns"),
-  flags = grid[, c("dropout1", "dropout2")], sample = 0.1
-)
-# check if an arbitrary run has been completed
-completed_runs <- runs[runs$completed]$id
-2 \%in\% completed_runs
-# continue evaluating the grid if the process was paused / interrupted etc.
-grid <- grid[!(grid$id \%in\% completed_runs), ]
-runs <- tuning_run(
-  system.file("examples/mnist_mlp/mnist_mlp.R", package = "tfruns"),
-  flags = grid[, c("dropout1", "dropout2")], sample = 0.1
+  flags = grid[, c("dropout1", "dropout2")]
 )
 }
-
 }

--- a/tests/testthat/test-tuning.R
+++ b/tests/testthat/test-tuning.R
@@ -3,12 +3,48 @@ context("tuning")
 source("utils.R")
 
 test_that("tuning_run can execute multiple runs", {
-
   runs <- tuning_run("write_run_data.R", confirm = FALSE, flags = list(
     learning_rate = c(0.01, 0.02),
     max_steps = c(2500, 500)
   ))
 
   expect_equal(nrow(runs), 4)
+})
 
+test_that("tuning_run can correctly handles interaction of flags flag_grid", {
+
+  # specify only flag_grid
+  grid <- expand.grid(
+    learning_rate = c(0.01, 0.02),
+    max_steps = c(2500, 500, 99)
+  )
+  runs <- tuning_run("write_run_data.R",
+    confirm = FALSE, flag_grid = grid
+  )
+  expect_equal(nrow(runs), 6)
+
+  # specify both flag_grid and flags
+  expect_error(
+    tuning_run("write_run_data.R",
+      confirm = FALSE, flag_grid = grid,
+      flags = list(learning_rate = c(0.01, 0.02), max_steps = c(2500, 500))
+    ),
+    "either via the argument"
+  )
+
+  # specify none
+  expect_error(
+    tuning_run("write_run_data.R", confirm = FALSE),
+    "either via the argument"
+  )
+
+  # supply unnamed flags
+  # specify both flag_grid and flags
+  expect_error(
+    tuning_run("write_run_data.R",
+      confirm = FALSE,
+      flags = list(c(0.01, 0.02), c(2500, 500))
+    ),
+    "as a named list"
+  )
 })

--- a/tests/testthat/test-tuning.R
+++ b/tests/testthat/test-tuning.R
@@ -19,23 +19,14 @@ test_that("tuning_run can correctly handles interaction of flags flag_grid", {
     max_steps = c(2500, 500, 99)
   )
   runs <- tuning_run("write_run_data.R",
-    confirm = FALSE, flag_grid = grid
+    confirm = FALSE, flags = grid
   )
   expect_equal(nrow(runs), 6)
-
-  # specify both flag_grid and flags
-  expect_error(
-    tuning_run("write_run_data.R",
-      confirm = FALSE, flag_grid = grid,
-      flags = list(learning_rate = c(0.01, 0.02), max_steps = c(2500, 500))
-    ),
-    "either via the argument"
-  )
 
   # specify none
   expect_error(
     tuning_run("write_run_data.R", confirm = FALSE),
-    "either via the argument"
+    "flags must be specified as a named list"
   )
 
   # supply unnamed flags

--- a/tests/testthat/test-tuning.R
+++ b/tests/testthat/test-tuning.R
@@ -63,9 +63,9 @@ test_that("tuning_run can execute multiple runs", {
   expect_equal(nrow(runs), 4)
 })
 
-test_that("tuning_run can correctly handles different types of input for flags", {
+test_that("tuning_run can correctly handle different types of inputs for flags", {
 
-  # specify only flag_grid
+  # specify flags as data frame
   grid <- expand.grid(
     learning_rate = c(0.01, 0.02),
     max_steps = c(2500, 500, 99)
@@ -82,7 +82,6 @@ test_that("tuning_run can correctly handles different types of input for flags",
   ))
 
   # supply unnamed flags
-  # specify both flag_grid and flags
   expect_error(
     tuning_run("write_run_data.R",
       confirm = FALSE,


### PR DESCRIPTION
Closes #30. Adds argument `flag_grid` to `tuning_run()` to allow an explicit specification of all combinations to process, which makes it easy to remove some. From the example fo `tuning_run()`:

```r
# using the flag_grid argument, but remove combinations
# where the combined dropout rate exceeds 1
grid <- expand.grid(
  batch_size = 2^c(1:5),
  dropout1 = seq(0.2, 0.8, by = 0.1),
  dropout2 = seq(0.2, 0.8, by = 0.1)
)
grid$combined_droput <- grid$dropout1 + grid$dropout2
grid$id <- 1:nrow(grid)
grid <- grid[grid$combined_droput <= 1,]
runs <- tuning_run("mnist_mlp.R", flag_grid = grid, sample = 0.01)
```