### PR TITLE
Clean tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,8 @@ Imports:
 Suggests: 
     testthat,
     knitr,
-    withr
+    withr,
+    here
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,8 +50,9 @@ Imports:
   rstudioapi (>= 0.7),
   reticulate
 Suggests: 
-  testthat,
-  knitr
+    testthat,
+    knitr,
+    withr
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,3 +1,9 @@
+with_tests_dir <- function(code){
+  test_dir <- system.file("tests/testthat", package = "tfruns")
+  withr::with_dir(test_dir, code)
+}
+
+
 define_flags <- function(...) {
   flags(
     flag_numeric('learning_rate', 0.01, 'Initial learning rate.'),

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,5 +1,5 @@
 with_tests_dir <- function(code){
-  test_dir <- system.file("tests/testthat", package = "tfruns")
+  test_dir <- here::here("tests/testthat")
   withr::with_dir(test_dir, code)
 }
 

--- a/tests/testthat/test-copy.R
+++ b/tests/testthat/test-copy.R
@@ -4,13 +4,27 @@ context("copy")
 
 
 # context 3 fake training runs (one of which that generates files)
-with_tests_dir( latest_run() )
 
-with_tests_dir( training_run(view = FALSE, echo = FALSE) )
-with_tests_dir( training_run(view = FALSE, echo = FALSE) )
-with_tests_dir({
-  training_run("write_run_data.R", view = FALSE, echo = FALSE)
+test_that("can creat training runs",{
+  with_tests_dir({
+    lr <- training_run(view = FALSE, echo = FALSE)
+    expect_is(lr, "data.frame")
+  })
+  with_tests_dir({
+    training_run(view = FALSE, echo = FALSE)
+    expect_is(lr, "data.frame")
+  })
+  with_tests_dir({
+    training_run("write_run_data.R", view = FALSE, echo = FALSE)
+    expect_is(lr, "data.frame")
+  })
+
+  with_tests_dir({
+    lr <- latest_run()
+    expect_is(lr, "tfruns_run")
+  })
 })
+
 test_that("copy_run copies run directory", {
   with_tests_dir({
     copy_run(latest_run(), rename = "copied-run-dir")

--- a/tests/testthat/test-copy.R
+++ b/tests/testthat/test-copy.R
@@ -1,5 +1,3 @@
-if (interactive()) library(testthat)
-
 context("copy")
 
 

--- a/tests/testthat/test-copy.R
+++ b/tests/testthat/test-copy.R
@@ -5,7 +5,7 @@ context("copy")
 
 # context 3 fake training runs (one of which that generates files)
 
-test_that("can creat training runs",{
+test_that("can create training runs",{
   with_tests_dir({
     lr <- training_run(view = FALSE, echo = FALSE)
     expect_is(lr, "data.frame")

--- a/tests/testthat/test-copy.R
+++ b/tests/testthat/test-copy.R
@@ -1,33 +1,43 @@
+if (interactive()) library(testthat)
+
 context("copy")
 
-source("utils.R")
 
 # context 3 fake training runs (one of which that generates files)
-training_run()
-training_run()
-training_run("write_run_data.R")
+with_tests_dir( latest_run() )
 
+with_tests_dir( training_run(view = FALSE, echo = FALSE) )
+with_tests_dir( training_run(view = FALSE, echo = FALSE) )
+with_tests_dir({
+  training_run("write_run_data.R", view = FALSE, echo = FALSE)
+})
 test_that("copy_run copies run directory", {
-  copy_run(latest_run(), rename = "copied-run-dir")
-  expect_true(file.exists(file.path("copied-run-dir", "subdir", "extra.dat")))
-  expect_true(file.exists(file.path("copied-run-dir", "tfruns.d", "source.tar.gz")))
-  unlink("copied-run-dir", recursive = TRUE)
+  with_tests_dir({
+    copy_run(latest_run(), rename = "copied-run-dir")
+    expect_true(file.exists(file.path("copied-run-dir", "subdir", "extra.dat")))
+    expect_true(file.exists(file.path("copied-run-dir", "tfruns.d", "source.tar.gz")))
+    unlink("copied-run-dir", recursive = TRUE)
+  })
 })
 
 test_that("copy_run_files copies run artifacts", {
-  copy_run_files(latest_run(), rename = "run-artifacts")
-  expect_true(file.exists(file.path("run-artifacts", "extra.dat")))
-  unlink("run-artifacts", recursive = TRUE)
+  with_tests_dir({
+    copy_run_files(latest_run(), rename = "run-artifacts")
+    expect_true(file.exists(file.path("run-artifacts", "extra.dat")))
+    unlink("run-artifacts", recursive = TRUE)
+  })
 })
 
 test_that("copy_runs successfully copies run directories", {
-  last_3_runs <- ls_runs()[1:3,]
-  copy_run(last_3_runs, "last-three")
-  expect_true(all(
-    utils::file_test(
-      "-d", file.path("last-three", basename(as_run_dir(last_3_runs))))
-  ))
-  unlink("last-three", recursive = TRUE)
+  with_tests_dir({
+    last_3_runs <- ls_runs()[1:3,]
+    copy_run(last_3_runs, "last-three")
+    expect_true(all(
+      utils::file_test(
+        "-d", file.path("last-three", basename(as_run_dir(last_3_runs))))
+    ))
+    unlink("last-three", recursive = TRUE)
+  })
 })
 
 

--- a/tests/testthat/test-flags.R
+++ b/tests/testthat/test-flags.R
@@ -1,5 +1,3 @@
-if (interactive()) library(testthat)
-
 context("flags")
 
 test_that("flags can be defined", {

--- a/tests/testthat/test-flags.R
+++ b/tests/testthat/test-flags.R
@@ -1,53 +1,67 @@
+if (interactive()) library(testthat)
+
 context("flags")
 
-source("utils.R")
-
 test_that("flags can be defined", {
-  FLAGS <- define_flags()
-  expect_equivalent(FLAGS, readRDS("flags.rds"))
+  with_tests_dir({
+    FLAGS <- define_flags()
+    expect_equivalent(FLAGS, readRDS("flags.rds"))
+  })
 })
 
 test_that("flags are assigned the correct types", {
-  FLAGS <- define_flags()
-  expect_type(FLAGS$learning_rate, "double")
-  expect_type(FLAGS$max_steps, "integer")
-  expect_type(FLAGS$data_dir, "character")
-  expect_type(FLAGS$fake_data, "logical")
+  with_tests_dir({
+    FLAGS <- define_flags()
+    expect_type(FLAGS$learning_rate, "double")
+    expect_type(FLAGS$max_steps, "integer")
+    expect_type(FLAGS$data_dir, "character")
+    expect_type(FLAGS$fake_data, "logical")
+  })
 })
 
 test_that("flags_parse returns defaults when there are no overrides", {
-  FLAGS <- define_flags()
-  expect_equivalent(FLAGS, readRDS("flags.rds"))
+  with_tests_dir({
+    FLAGS <- define_flags()
+    expect_equivalent(FLAGS, readRDS("flags.rds"))
+  })
 })
 
 test_that("flags_parse overrides based on command line args", {
-  FLAGS <- define_flags(arguments = c("--learning-rate", "0.02"))
-  expect_equal(FLAGS$learning_rate, 0.02)
+  with_tests_dir({
+    FLAGS <- define_flags(arguments = c("--learning-rate", "0.02"))
+    expect_equal(FLAGS$learning_rate, 0.02)
+  })
 })
 
 test_that("flags_parse throws an error for unknown command line args", {
-  expect_error({
-    FLAGS <- define_flags(arguments = c("--learn-rate", "0.02"))
+  with_tests_dir({
+    expect_error({
+      FLAGS <- define_flags(arguments = c("--learn-rate", "0.02"))
+    })
   })
 })
 
 test_that("flags_parse overrides based on config file values", {
-  FLAGS <- define_flags(file = "flags-override.yml")
-  expect_equal(FLAGS$learning_rate, 0.02)
-  FLAGS <- define_flags(file = "flags-profile-override.yml", config = "myconfig")
-  expect_equal(FLAGS$learning_rate, 0.03)
+  with_tests_dir({
+    FLAGS <- define_flags(file = "flags-override.yml")
+    expect_equal(FLAGS$learning_rate, 0.02)
+    FLAGS <- define_flags(file = "flags-profile-override.yml", config = "myconfig")
+    expect_equal(FLAGS$learning_rate, 0.03)
+  })
 })
 
 test_that("flags_parse skips --args for passthrough args", {
-  FLAGS <- flags(
-    flag_numeric("gradient_descent_optimizer", 0.5),
-    arguments = list(
-      "--gradient-descent-optimizer",
-      "0.47",
-      "--args",
-      "--job-dir",
-      "gs://rstudio-cloudml/mnist/staging/2")
-  )
+  with_tests_dir({
+    FLAGS <- flags(
+      flag_numeric("gradient_descent_optimizer", 0.5),
+      arguments = list(
+        "--gradient-descent-optimizer",
+        "0.47",
+        "--args",
+        "--job-dir",
+        "gs://rstudio-cloudml/mnist/staging/2")
+    )
 
-  expect_equal(FLAGS$gradient_descent_optimizer, 0.47)
+    expect_equal(FLAGS$gradient_descent_optimizer, 0.47)
+  })
 })

--- a/tests/testthat/test-run-data.R
+++ b/tests/testthat/test-run-data.R
@@ -1,5 +1,3 @@
-if (interactive()) library(testthat)
-
 context("run_data")
 
 

--- a/tests/testthat/test-run-data.R
+++ b/tests/testthat/test-run-data.R
@@ -1,11 +1,20 @@
+if (interactive()) library(testthat)
+
 context("run_data")
 
-source("utils.R")
 
-run_dir <- training_run("write_run_data.R")$run_dir
+run_dir <- with_tests_dir({
+  x <- training_run("write_run_data.R", echo = FALSE)$run_dir
+  normalizePath(x, winslash = "/")
+})
+
 
 run_data <- function(...) {
-  file.path(run_dir, "tfruns.d", ...)
+  with_tests_dir({
+    run_dir <- training_run("write_run_data.R", echo = FALSE)$run_dir
+    run_dir <- normalizePath(run_dir, winslash = "/")
+    file.path(run_dir, "tfruns.d", ...)
+  })
 }
 
 expect_run_data <- function(...) {

--- a/tests/testthat/test-runs.R
+++ b/tests/testthat/test-runs.R
@@ -1,6 +1,12 @@
+if (interactive()) library(testthat)
+
 context("runs")
 
-run_dir <- training_run()$run_dir
+run_dir <- with_tests_dir({
+  x <- training_run(echo = FALSE)$run_dir
+  normalizePath(x, winslash = "/")
+})
+
 
 test_that("run dir is created by initialize_run()", {
   expect_true(dir.exists(run_dir))
@@ -12,41 +18,53 @@ test_that("list runs returns a data frame", {
   expect_true(all(c("start", "run_dir") %in% colnames(runs)))
 })
 
-test_that("latest_run retreives run_dir", {
-  expect_identical(run_dir, latest_run()$run_dir)
+test_that("latest_run retrieves run_dir", {
+  with_tests_dir({
+    expect_identical(basename(run_dir), basename(latest_run()$run_dir))
+  })
 })
 
 test_that("completed flag is set by training_run", {
-  expect_true(ls_runs(latest_n = 1)$completed)
+  with_tests_dir({
+    expect_true(ls_runs(latest_n = 1)$completed)
+  })
 })
 
 
 test_that("clean_runs and purge_runs remove runs", {
   # then clean
-  clean_runs(confirm = FALSE)
-  expect_equal(nrow(ls_runs()), 0)
-  expect_true(nrow(ls_runs(runs_dir = "runs/archive")) > 0)
+  with_tests_dir({
+    clean_runs(confirm = FALSE)
+    expect_equal(nrow(ls_runs()), 0)
+    expect_true(nrow(ls_runs(runs_dir = "runs/archive")) > 0)
 
-  # then purge
-  purge_runs(confirm = FALSE)
-  expect_equal(nrow(ls_runs(runs_dir = "runs/archive")), 0)
+    # then purge
+    purge_runs(confirm = FALSE)
+    expect_equal(nrow(ls_runs(runs_dir = "runs/archive")), 0)
+  })
 })
 
 test_that("flags.yml can be passed to training_run", {
-  training_run(flags = "flags-learning-rate.yml")
-  expect_equal(ls_runs(latest_n = 1)$flag_learning_rate, 0.05)
+  with_tests_dir({
+    training_run(flags = "flags-learning-rate.yml", echo = FALSE)
+    expect_equal(ls_runs(latest_n = 1)$flag_learning_rate, 0.05)
+  })
 })
 
 test_that("training errors are handled", {
-  tryCatch({
-      training_run("train-error.R")
-    },
-    error = function(e) {
+  tryCatch(
+    {
+      with_tests_dir({
+        training_run("train-error.R", echo = FALSE)
+      })
+    }, error = function(e) {
       expect_equal(e$message, "Training error occurred")
     }
   )
 
-  run <- ls_runs(latest_n = 1)
+  run <- with_tests_dir({
+    ls_runs(latest_n = 1)
+  })
 
   expect_true(!run$completed)
   expect_equal(run$error_message, "Training error occurred")

--- a/tests/testthat/test-runs.R
+++ b/tests/testthat/test-runs.R
@@ -1,5 +1,3 @@
-if (interactive()) library(testthat)
-
 context("runs")
 
 run_dir <- with_tests_dir({

--- a/tests/testthat/test-tuning.R
+++ b/tests/testthat/test-tuning.R
@@ -1,14 +1,25 @@
-context("tuning")
+if (interactive()) library(testthat)
 
-source("utils.R")
+context("tuning")
 
 test_that("tuning_run can execute multiple runs", {
 
-  runs <- tuning_run("write_run_data.R", confirm = FALSE, flags = list(
-    learning_rate = c(0.01, 0.02),
-    max_steps = c(2500, 500)
-  ))
+  runs <- with_tests_dir({
+    tuning_run("write_run_data.R",
+               confirm = FALSE,
+               flags = list(
+                 learning_rate = c(0.01, 0.02),
+                 max_steps = c(2500, 500)
+               ),
+               echo = FALSE
+    )
+  })
 
   expect_equal(nrow(runs), 4)
 
 })
+
+
+# tear down
+runs_dirs <- with_tests_dir(normalizePath(list.dirs("runs", recursive = FALSE)))
+unlink(runs_dirs, recursive = TRUE)

--- a/tests/testthat/test-tuning.R
+++ b/tests/testthat/test-tuning.R
@@ -1,5 +1,3 @@
-if (interactive()) library(testthat)
-
 context("tuning")
 
 test_that("tuning_run can execute multiple runs", {

--- a/tests/testthat/train.R
+++ b/tests/testthat/train.R
@@ -1,5 +1,5 @@
 
-# train script callbed by training_run in tests
+# train script called by training_run in tests
 
 library(tfruns)
 


### PR DESCRIPTION
Clean up tests to:

- Use `helper.R` instead of `source(utils.R)`
- Run all tests in tests directory, using `with_tests_dir()`, defined in `helpers.R`
- Run `training_run()` and `tuning_run()` with `echo=FALSE`, to ensure clean testthat log
- Clean up `runs` folder at end
- Ensure tests can run in `interactive()` (solved by  `with_tests_dir()`)

