### PR TITLE
Update docs for CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,5 +60,5 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.3.2
 VignetteBuilder: knitr

--- a/R/flags.R
+++ b/R/flags.R
@@ -30,7 +30,7 @@
 #'
 #' Command line flags should be of the form `--key=value` or
 #' `--key value`. The values are assumed to be valid `yaml` and
-#' will be converted using [yaml.load()].
+#' will be converted using [yaml::yaml.load()].
 #'
 #' @examples
 #' \dontrun{

--- a/man/flags.Rd
+++ b/man/flags.Rd
@@ -64,7 +64,7 @@ details).
 
 Command line flags should be of the form \code{--key=value} or
 \verb{--key value}. The values are assumed to be valid \code{yaml} and
-will be converted using \code{\link[=yaml.load]{yaml.load()}}.
+will be converted using \code{\link[yaml:yaml.load]{yaml::yaml.load()}}.
 }
 
 \examples{


### PR DESCRIPTION
Fixes:

Found the following Rd file(s) with Rd \link{} targets missing package
anchors:
  flags.Rd: yaml.load
Please provide package anchors for all Rd \link{} targets not in the
package itself and the base packages.